### PR TITLE
chore: replace backslah with slash in codegen.yml on Windows OS #155

### DIFF
--- a/packages/codegen/src/generators/react-typescript/app/template-model.ts
+++ b/packages/codegen/src/generators/react-typescript/app/template-model.ts
@@ -10,5 +10,5 @@ export const deriveTemplateModel = async <O extends AmplicodeCommonOptions, A, T
   _schema?: GraphQLSchema,
   schemaPath?: string
 ): Promise<T> => {
-  return {... answers as unknown as T, schemaPath};
+  return {... answers as unknown as T, schemaPath: schemaPath?.replace(/\\/g, "/")};
 }


### PR DESCRIPTION
affects: @amplicode/codegen