### PR TITLE
fix: generate correct path to graphQL schema in codegen.yml

### DIFF
--- a/packages/codegen/src/building-blocks/stages/graphql-schema/amplicodeGetGraphQLSchema.ts
+++ b/packages/codegen/src/building-blocks/stages/graphql-schema/amplicodeGetGraphQLSchema.ts
@@ -32,8 +32,8 @@ export const amplicodeGetGraphQLSchema = async <O extends AmplicodeCommonOptions
 
   const schemaPathAbsolute = getSchemaPath(invocationDir, options.schema);
 
-  const {dest = invocationDir} = options;
-  const codegenYmlPath = path.resolve(dest);
+  const {dest = ''} = options;
+  const codegenYmlPath = path.join(invocationDir, dest);
   const schemaPathRelativeToCodegenYml = path.relative(codegenYmlPath, schemaPathAbsolute);
 
   if (!fs.existsSync(schemaPathAbsolute)) {


### PR DESCRIPTION
affects: @amplicode/codegen