### PR TITLE
fix: generate nice looking captions for enum constants #358

### DIFF
--- a/packages/codegen/src/building-blocks/includes/AmplicodeFormField.ejs
+++ b/packages/codegen/src/building-blocks/includes/AmplicodeFormField.ejs
@@ -23,7 +23,7 @@
   <% } else if (attr.enumOptions != null) { -%>
     <Select <% if (index === 0) { -%> autoFocus <% } -%> >
       <% attr.enumOptions.forEach(opt => { -%>
-        <Select.Option value="<%= opt.value %>"><%= opt.name %></Select.Option>
+        <Select.Option value="<%= opt.value %>"><%= fatSnakeToNormal(opt.name) %></Select.Option>
       <% }) -%>
     </Select>
   <% } else if (attr.isRelationField) { %>

--- a/packages/codegen/src/building-blocks/stages/template-model/pieces/util.ts
+++ b/packages/codegen/src/building-blocks/stages/template-model/pieces/util.ts
@@ -1,6 +1,7 @@
 import {toFatSnakeCase} from "../../../util/to-fat-snake-case";
 import {capitalizeFirst, splitByCapitalLetter, unCapitalizeFirst} from "../../../../common/utils";
 import {dollarsToUnderscores} from "../../../util/dollars-to-underscores";
+import {fatSnakeToNormal} from "../../../util/fat-snake-to-normal";
 
 export type UtilTemplateModel = {
   toFatSnakeCase: (str: string) => string;
@@ -8,6 +9,7 @@ export type UtilTemplateModel = {
   dollarsToUnderscores: (str: string) => string;
   splitByCapitalLetter: (str: string) => string;
   capitalizeFirst: (str: string) => string;
+  fatSnakeToNormal: (str: string) => string;
 };
 
 /**
@@ -20,4 +22,5 @@ export const templateUtilities: UtilTemplateModel = {
   dollarsToUnderscores,
   splitByCapitalLetter,
   capitalizeFirst,
+  fatSnakeToNormal
 };

--- a/packages/codegen/src/building-blocks/util/fat-snake-to-normal.test.ts
+++ b/packages/codegen/src/building-blocks/util/fat-snake-to-normal.test.ts
@@ -1,0 +1,8 @@
+import { fatSnakeToNormal } from './fat-snake-to-normal';
+import {expect} from "chai";
+
+describe('fatSnakeToNormal()', () => {
+  it('replaces FAT_SNAKE_CASE with Normal text', () => {
+    expect(fatSnakeToNormal('ABC_DEF')).eq('Abc def');
+  });
+});

--- a/packages/codegen/src/building-blocks/util/fat-snake-to-normal.ts
+++ b/packages/codegen/src/building-blocks/util/fat-snake-to-normal.ts
@@ -1,0 +1,10 @@
+/**
+ * Transforms FAT_SNAKE_CASE to Normal text.
+ *
+ * @param str
+ */
+export const fatSnakeToNormal = (str: string): string => {
+	return str.charAt(0) + str.slice(1)
+    .replace(/_/g, ' ')
+    .toLowerCase()
+}; 


### PR DESCRIPTION
affects: @amplicode/codegen