### PR TITLE
chore: changelog links point to jmix repo #457

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/haulmont/jmix-frontend/tree/master/packages/jmix-front-generator"
+    "url": "https://github.com/Amplicode/amplicode-frontend"
   },
   "dependencies": {
     "@graphql-tools/load": "^7.1.2",


### PR DESCRIPTION
affects: @amplicode/codegen